### PR TITLE
Enhancement: Shell Cache

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,4 +7,4 @@ exclude_lines =
     raise NotImplementedError
 
 [run]
-omit = *tests*,*shell*
+omit = *tests*,shell.py

--- a/deucevalere/api/shell_cache.py
+++ b/deucevalere/api/shell_cache.py
@@ -1,0 +1,450 @@
+"""
+Deuce Valere - API - Shell Cache
+"""
+from builtins import NotADirectoryError
+import datetime
+import json
+import logging
+import os
+import os.path
+import tempfile
+
+from stoplight import validate
+from deuceclient.common.validation import *
+from deuceclient.common.validation_instance import *
+
+from deucevalere.api.system import Manager
+from deucevalere.common.validation import ExpireAgeRuleNoneOkay
+from deucevalere.common.validation_instance import ValereManagerRule
+
+
+class ExpiredCacheData(Exception):
+    pass
+
+
+class NoCachedData(Exception):
+    pass
+
+
+class ShellCache(object):
+    """A simple cache mechanism for caching the manager and related data
+
+        This is primarily for use by the Deuce-Valere Shell so that
+        information can be cached between runs without requiring the user
+        to provide all the information for each step or do steps multiple
+        times just to have the data.
+
+        For instance, if the user validates a vault in one instance there
+        is then information they would need to provide back to the shell
+        in order to clean it. Either the information must be provided by
+        the user (not good) or we need some way to cache it between runs.
+
+        This cache is NOT thread/process safe. Multiple processes/threads
+        can use it so long as they are not operating on overlapping ranges
+        within a vault. For instance any of the following would not be
+        good as start/stop ranges (assuming the single letters would
+        qualify as markers):
+            [None, None]
+            [0, F)
+            [9, Z)
+            [None, G)
+            [5, None]
+    """
+
+    defaults = {
+        # Because HOME might not be defined in some environments
+        # This is mainly to solve the issue of when the project
+        # gets compiled and HOME is not defined in the environment
+        # the compiler is running under to keep the compiler evaluation
+        # from failing
+        'base': os.environ['HOME']
+        if os.environ['HOME'] else temp.gettempdir(),
+
+        'dirname': '.deuce_valere'
+    }
+
+    @classmethod
+    def default_directory(cls):
+        """Return the default path for the cache
+        """
+        return os.path.join(ShellCache.defaults['base'],
+                            ShellCache.defaults['dirname'])
+
+    def __init__(self):
+        self.log = logging.getLogger(__name__)
+        # Note: 'base' and 'dirname' are only checked for being valid
+        #       and usable if either (i) they are changed or
+        #       (ii) something is uses the cache. Thus just creating
+        #       an instance of ShellCache will not try to create the
+        #       locations the cache uses
+        self.__cache_info = {
+            'base': self.defaults['base'],
+            'dirname': self.defaults['dirname']
+        }
+
+    def __check_path_exists(self, path):
+        if not os.path.exists(path):
+            os.mkdir(path)
+            if os.path.exists(path):
+                self.log.debug('Path exists - {0}'.format(path))
+                return True
+            else:
+                raise NotADirectoryError(
+                    '{0} is not a path on disk'.format(path))
+        elif os.path.isdir(path):
+            self.log.debug('Path is a directory - {0}'.format(path))
+            return True
+        else:
+            raise NotADirectoryError(
+                '{0} is not a path on disk'.format(path))
+
+    def __check_dir_name_exists(self, dirname=None):
+        path = self.cache_dir
+        if dirname is not None:
+            path = os.path.join(self.base,
+                                dirname)
+        return self.__check_path_exists(path)
+
+    @property
+    def base(self):
+        """Active Base directory for where the cache will be stored under
+
+        Default: os.environ['HOME'] if defined, otherwise TEMPDIR as
+            defined by tempfile.gettempdir()
+        """
+        return self.__cache_info['base']
+
+    @base.setter
+    def base(self, value):
+        """Set a new base directory
+
+        Path must exist on disk and be a directory, or be createable by
+        the current user.
+
+        :parameter value: str - directory name (path) of the base
+
+        :returns: N/A
+        :raises:
+            NotADirectoryError if parameter is not a directory or
+                               a directory by that specification could not
+                               be created
+        """
+        if value is None:
+            value = ShellCache.defaults['base']
+
+        self.__check_path_exists(value)
+        self.__cache_info['base'] = value
+
+    @property
+    def dirname(self):
+        """Directory name under Manager.base that will be used for the cache
+        """
+        return self.__cache_info['dirname']
+
+    @dirname.setter
+    def dirname(self, value):
+        """Set a new cache directory under the base
+
+        Path must exist on disk under Manager.base and be a directory,
+        or be createable as such by the current user.
+
+        :parameter value: str - directory name to use
+
+        :returns: N/A
+        :raises:
+            NotADirectoryError if parameter is not a directory or
+                               a directory by that specification could not
+                               be created
+        """
+        if value is None:
+            value = ShellCache.defaults['dirname']
+
+        self.__check_dir_name_exists(dirname=value)
+        self.__cache_info['dirname'] = value
+
+    @property
+    def cache_dir(self):
+        """The path to the active cache
+        """
+        return os.path.join(self.base, self.dirname)
+
+    @validate(vault=VaultInstanceRule,
+              start_block=MetadataBlockIdRuleNoneOkay,
+              end_block=MetadataBlockIdRuleNoneOkay)
+    def __get_key(self, vault, start_block, end_block):
+        """(Internal) Get the key for given vault and markers
+
+        :parameter vault: instance of deuceclient.api.Vault
+        :parameter start_block: str - block_id in Vault for the start block
+                                      or None
+        :parameter end_block: str - block_id in Vault for the end block
+                                    or None
+
+        :returns: str - key to use for the specified parameters
+        """
+
+        # Base key name
+        key = '{0}__{1}'.format(vault.project_id,
+                                vault.vault_id)
+
+        # Add the start marker if it exists
+        if start_block is not None:
+            key = '{0}_start_{1}'.format(key,
+                                         start_block)
+
+        # Add the end marker if it exists
+        if end_block is not None:
+            key = '{0}_end_{1}'.format(key,
+                                       end_block)
+
+        # log the resulting key
+        self.log.info('Key: Project {0}, Vault {1}, Manager [{2},{3}) => {4}'
+                      .format(vault.project_id,
+                              vault.vault_id,
+                              start_block,
+                              end_block,
+                              key))
+        return key
+
+    def __get_manager_cache_file(self, key):
+        """Get the cache file name for the manager data
+
+        :parameter key: str - key for the data
+
+        :returns: str - filename to use for caching the manager data
+        """
+        self.__check_dir_name_exists()
+        manager_key = 'cached_manager_{0}'.format(key)
+        return os.path.join(self.cache_dir, manager_key)
+
+    def __get_vault_cache_file(self, key):
+        """Get the cache file name for the vault data
+
+        :parameter key: str - key for the data
+
+        :returns: str - filename to use for caching the vault data
+        """
+        self.__check_dir_name_exists()
+        vault_key = 'cached_vault_{0}'.format(key)
+        return os.path.join(self.cache_dir, vault_key)
+
+    @validate(vault=VaultInstanceRule,
+              manager=ValereManagerRule)
+    def add_manager(self, vault, manager):
+        """Add the manager to the cache
+
+        :parameter vault: instance of deuceclient.api.Vault
+        :parameter manager: instance of deucevalere.api.system.Manager
+
+        :returns: True on success
+        :raises: Passes thru any exceptions while trying to write
+                 the data to disk
+        """
+        now = datetime.datetime.utcnow()
+        json_data = json.dumps({
+            'timestamp': {
+                'year': now.year,
+                'month': now.month,
+                'day': now.day,
+                'hour': now.hour,
+                'minute': now.minute,
+                'second': now.second,
+                'microsecond': now.microsecond
+            },
+            'manager': manager.to_json()
+        })
+
+        key = self.__get_key(vault,
+                             manager.start_block,
+                             manager.end_block)
+
+        file_name = self.__get_manager_cache_file(key)
+        self.log.info('Writing cached data to {0}'.format(file_name))
+
+        try:
+            with open(file_name, 'w') as data_store:
+                data_store.write(json_data)
+                return True
+        except Exception as ex:
+            self.log.error(
+                'Error while writing to cache: {0}'.format(str(ex)))
+            raise
+
+    @validate(vault=VaultInstanceRule,
+              start_block=MetadataBlockIdRuleNoneOkay,
+              end_block=MetadataBlockIdRuleNoneOkay,
+              cache_age_max=ExpireAgeRuleNoneOkay)
+    def get_manager(self, vault, start_block, end_block, cache_age_max):
+        """Retrieve the cached data from disk
+
+        :parameter vault: instance of deuceclient.api.Vault
+        :parameter start_block: str - block_id in Vault for the start block
+                                      or None
+        :parameter end_block: str - block_id in Vault for the end block
+                                    or None
+        :parameter cache_age_max: instance of datetime.timedeleta specifying
+                                  the maximum age of the cached value
+                                  or None
+        :returns: instance of deucevalere.api.system.Manager if able to
+                  load data from the cache
+        :raises: Passes thru any exceptions while trying to read the
+                 data from disk.
+        :raises: ExpiredCacheData if the cached data is too old
+        :raises: NoCachedData if no data in the cache
+        """
+        key = self.__get_key(vault,
+                             start_block,
+                             end_block)
+
+        file_name = self.__get_manager_cache_file(key)
+        self.log.info('Reading cached data from {0}'.format(file_name))
+
+        if os.path.isfile(file_name):
+            try:
+                with open(file_name, 'r') as data_store:
+                    json_data = json.loads(data_store.read())
+
+                    if cache_age_max is None:
+                        return Manager.from_json(json_data['manager'])
+
+                    else:
+                        then = datetime.datetime(
+                            year=json_data['timestamp']['year'],
+                            month=json_data['timestamp']['month'],
+                            day=json_data['timestamp']['day'],
+                            hour=json_data['timestamp']['hour'],
+                            minute=json_data['timestamp']['minute'],
+                            second=json_data['timestamp']['second'],
+                            microsecond=json_data['timestamp']['microsecond'])
+                        cache_data_age = (datetime.datetime.utcnow() -
+                                          then)
+
+                        if cache_data_age < cache_age_max:
+                            return Manager.from_json(json_data['manager'])
+                        else:
+                            raise ExpiredCacheData(
+                                'Cached data in {0} from {1} < {2} -> expired '
+                                'with age {3}'
+                                .format(key,
+                                        json_data['timestamp'],
+                                        cache_age_max,
+                                        cache_data_age))
+            except Exception as ex:
+                self.log.error(
+                    'Error while reading from cache: {0}'.format(str(ex)))
+                raise
+        else:
+            raise NoCachedData('No data in cache')
+
+    @validate(vault=VaultInstanceRule,
+              manager=ValereManagerRule)
+    def add_vault(self, vault, manager):
+        """Add the vault to the cache
+
+        :parameter vault: instance of deuceclient.api.Vault
+        :parameter manager: instance of deucevalere.api.system.Manager
+
+        :returns: True on success
+        :raises: Passes thru any exceptions while trying to write
+                 the data to disk
+        """
+        now = datetime.datetime.utcnow()
+        json_data = json.dumps({
+            'timestamp': {
+                'year': now.year,
+                'month': now.month,
+                'day': now.day,
+                'hour': now.hour,
+                'minute': now.minute,
+                'second': now.second,
+                'microsecond': now.microsecond
+            },
+            'vault': json.dumps(None)
+        })
+
+        key = self.__get_key(vault,
+                             manager.start_block,
+                             manager.end_block)
+
+        file_name = self.__get_vault_cache_file(key)
+        self.log.info('Writing cached data to {0}'.format(file_name))
+
+        try:
+            with open(file_name, 'w') as data_store:
+                data_store.write(json_data)
+                return True
+        except Exception as ex:
+            self.log.error(
+                'Error while writing to cache: {0}'.format(str(ex)))
+            raise
+
+    @validate(vault=VaultInstanceRule,
+              start_block=MetadataBlockIdRuleNoneOkay,
+              end_block=MetadataBlockIdRuleNoneOkay,
+              cache_age_max=ExpireAgeRuleNoneOkay)
+    def get_vault(self, vault, start_block, end_block, cache_age_max):
+        """Retrieve the cached data from disk
+
+        :parameter vault: instance of deuceclient.api.Vault
+        :parameter start_block: str - block_id in Vault for the start block
+                                      or None
+        :parameter end_block: str - block_id in Vault for the end block
+                                    or None
+        :parameter cache_age_max: instance of datetime.timedeleta specifying
+                                  the maximum age of the cached value
+                                  or None
+        :returns: instance of deucevalere.api.system.Manager if able to
+                  load data from the cache
+        :raises: Passes thru any exceptions while trying to read the
+                 data from disk.
+        :raises: ExpiredCacheData if the cached data is too old
+        :raises: NoCachedData if no data in the cache
+        """
+        key = self.__get_key(vault,
+                             start_block,
+                             end_block)
+
+        file_name = self.__get_vault_cache_file(key)
+        self.log.info('Reading cached data from {0}'.format(file_name))
+
+        if os.path.isfile(file_name):
+            self.log.info('Found cache file {0}'.format(file_name))
+            try:
+                with open(file_name, 'r') as data_store:
+                    self.log.debug('File opened')
+                    json_data = json.loads(data_store.read())
+                    self.log.debug('File read and parsed')
+
+                    if cache_age_max is None:
+                        raise NotImplementedError(
+                            'Vault Deserialization not implemented')
+
+                    else:
+                        then = datetime.datetime(
+                            year=json_data['timestamp']['year'],
+                            month=json_data['timestamp']['month'],
+                            day=json_data['timestamp']['day'],
+                            hour=json_data['timestamp']['hour'],
+                            minute=json_data['timestamp']['minute'],
+                            second=json_data['timestamp']['second'],
+                            microsecond=json_data['timestamp']['microsecond'])
+                        cache_data_age = (datetime.datetime.utcnow() -
+                                          then)
+
+                        if cache_data_age < cache_age_max:
+                            raise NotImplementedError(
+                                'Vault Deserialization not implemented')
+                        else:
+                            raise ExpiredCacheData(
+                                'Cached data in {0} from {1} < {2} -> expired '
+                                'with age {3}'
+                                .format(key,
+                                        json_data['timestamp'],
+                                        cache_age_max,
+                                        cache_data_age))
+            except Exception as ex:
+                self.log.error(
+                    'Error while reading from cache: {0}'.format(str(ex)))
+                raise
+        else:
+            raise NoCachedData('No data in cache')

--- a/deucevalere/tests/client_base.py
+++ b/deucevalere/tests/client_base.py
@@ -49,6 +49,56 @@ class TestValereClientBase(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
 
+    def check_time_manager(self, a, b):
+        self.assertEqual(a.name, b.name)
+        self.assertEqual(a.start, b.start)
+        self.assertEqual(a.end, b.end)
+
+    def check_counter_manager(self, a, b):
+        self.assertEqual(a.name, b.name)
+        self.assertEqual(a.count, b.count)
+        self.assertEqual(a.size, b.size)
+
+    def check_list_manager(self, a, b):
+        def __check_list(c, d):
+            if c is None:
+                self.assertIsNone(d)
+            else:
+                self.assertEqual(c, d)
+
+        self.assertEqual(a.name, b.name)
+        __check_list(a.current, b.current)
+        __check_list(a.expired, b.expired)
+        __check_list(a.deleted, b.deleted)
+        __check_list(a.orphaned, b.orphaned)
+
+    def check_manager(self, a, b):
+        def __check_marker(c, d):
+            if c is None:
+                self.assertIsNone(d)
+            else:
+                self.assertEqual(c, d)
+
+        self.assertEqual(a.expire_age, b.expire_age)
+        __check_marker(a.start_block, b.start_block)
+        __check_marker(a.end_block, b.end_block)
+        self.check_time_manager(a.validation_timer,
+                                b.validation_timer)
+        self.check_time_manager(a.cleanup_timer,
+                                b.cleanup_timer)
+        self.check_counter_manager(a.expired_counter,
+                                   b.expired_counter)
+        self.check_counter_manager(a.missing_counter,
+                                   b.missing_counter)
+        self.check_counter_manager(a.orphaned_counter,
+                                   b.orphaned_counter)
+        self.check_list_manager(a.metadata,
+                                b.metadata)
+        self.check_list_manager(a.storage,
+                                b.storage)
+        self.assertEqual(a.cross_reference,
+                         b.cross_reference)
+
     def get_metadata_block_pattern_matcher(self):
         base_url = get_blocks_url(self.apihost, self.vault.vault_id)
         regex = '{0:}/{1:}'.format(base_url[8:],

--- a/deucevalere/tests/test_api_shell_cache.py
+++ b/deucevalere/tests/test_api_shell_cache.py
@@ -1,0 +1,297 @@
+"""
+Deuce Valere - Tests - API - Shell Cache
+"""
+import builtins
+import os
+import os.path
+import tempfile
+import unittest
+
+from deuceclient.api import Vault
+from deuceclient.tests import *
+import mock
+
+from deucevalere.api.shell_cache import *
+from deucevalere.api.system import Manager
+from deucevalere.tests.client_base import TestValereClientBase
+
+
+class DeuceValereApiShellCacheTest(TestValereClientBase):
+
+    def setUp(self):
+        super().setUp()
+        self.project_id = create_project_name()
+        self.vault_id = create_vault_name()
+        self.vault = Vault(self.project_id,
+                           self.vault_id)
+        self.manager = Manager()
+
+        self.cache_dir_object = tempfile.TemporaryDirectory()
+        self.cache_dir = self.cache_dir_object.name
+
+        # Note: Aside from the test_shell_cache_create()
+        #       all tests should reset self.case.base to
+        #       self.cache_dir so that cleanup happens properly
+        #       and automatically after the test is complete
+        self.cache = ShellCache()
+
+    def tearDown(self):
+        super().tearDown()
+        self.cache_dir_object.cleanup()
+
+    def test_shell_cache_default_path(self):
+        self.assertEqual(ShellCache.default_directory(),
+                         os.path.join(ShellCache.defaults['base'],
+                                      ShellCache.defaults['dirname']))
+
+    def test_shell_cache_create(self):
+        if os.environ['HOME']:
+            self.assertEqual(self.cache.base,
+                             os.environ['HOME'])
+        else:
+            self.assertEqual(self.cache.base,
+                             tempfile.gettempdir())
+        self.assertEqual(self.cache.base,
+                         ShellCache.defaults['base'])
+
+        self.assertEqual(self.cache.dirname,
+                         '.deuce_valere')
+        self.assertEqual(self.cache.dirname,
+                         ShellCache.defaults['dirname'])
+
+    def test_shell_cache_set_base(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.assertNotEqual(self.cache.base,
+                            ShellCache.defaults['base'])
+        self.assertEqual(self.cache.dirname,
+                         ShellCache.defaults['dirname'])
+
+    def test_shell_cache_set_base_reset(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.assertNotEqual(self.cache.base,
+                            ShellCache.defaults['base'])
+        self.cache.base = None
+        self.assertEqual(self.cache.base,
+                         ShellCache.defaults['base'])
+        self.assertNotEqual(self.cache.base,
+                            self.cache_dir)
+
+    def test_shell_cache_set_dirname(self):
+        dirname = '.deuce-valere-test'
+
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.cache.dirname = dirname
+        self.assertEqual(self.cache.dirname,
+                         dirname)
+
+    def test_shell_cache_set_dirname_reset(self):
+        dirname = '.deuce-valere-test'
+
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.cache.dirname = dirname
+        self.assertEqual(self.cache.dirname,
+                         dirname)
+        self.assertNotEqual(self.cache.dirname,
+                            ShellCache.defaults['dirname'])
+        self.cache.dirname = None
+        self.assertEqual(self.cache.dirname,
+                         ShellCache.defaults['dirname'])
+        self.assertNotEqual(self.cache.dirname,
+                            dirname)
+
+    def test_shell_cache_set_dirname_failure_create(self):
+        dirname = '.deuce-valere-test'
+
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+
+        with mock.patch('os.path.exists') as mok_exists:
+            with mock.patch('os.mkdir') as mok_mkdir:
+                mok_exists.side_effect = [False, False]
+                mok_mkdir.return_value = None
+                with self.assertRaises(builtins.NotADirectoryError):
+                    self.cache.dirname = dirname
+
+    def test_shell_cache_set_dirname_failure_exists(self):
+        dirname = '.deuce-valere-test'
+
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+
+        with mock.patch('os.path.exists') as mok_exists:
+            with mock.patch('os.path.isdir') as mok_isdir:
+                mok_exists.return_value = True
+                mok_isdir.return_value = False
+                with self.assertRaises(builtins.NotADirectoryError):
+                    self.cache.dirname = dirname
+
+    def test_shell_cache_manager_basic(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.cache.add_manager(self.vault, self.manager)
+
+        new_manager = self.cache.get_manager(self.vault,
+                                             None,
+                                             None,
+                                             None)
+
+        self.check_manager(self.manager,
+                           new_manager)
+
+    def test_shell_cache_manager_basic_with_age(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.cache.add_manager(self.vault, self.manager)
+
+        expire_age = datetime.timedelta(weeks=52)
+        new_manager = self.cache.get_manager(self.vault,
+                                             None,
+                                             None,
+                                             expire_age)
+
+        self.check_manager(self.manager,
+                           new_manager)
+
+    def test_shell_cache_manager_expired(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.cache.add_manager(self.vault, self.manager)
+
+        expire_age = datetime.timedelta(microseconds=5)
+        with self.assertRaises(ExpiredCacheData):
+            new_manager = self.cache.get_manager(self.vault,
+                                                 None,
+                                                 None,
+                                                 expire_age)
+
+    def test_shell_cache_manager_no_data(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+
+        with self.assertRaises(NoCachedData):
+            new_manager = self.cache.get_manager(self.vault,
+                                                 None,
+                                                 None,
+                                                 None)
+
+    def test_shell_cache_manager_basic_with_start_end(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+
+        start_block = create_block()[0]
+        end_block = create_block()[0]
+        self.manager = Manager(start_block, end_block)
+
+        self.cache.add_manager(self.vault, self.manager)
+
+        new_manager = self.cache.get_manager(self.vault,
+                                             start_block,
+                                             end_block,
+                                             None)
+
+        self.check_manager(self.manager,
+                           new_manager)
+
+    def test_shell_cache_add_manager_failure(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+
+        with mock.patch('builtins.open',
+                        mock.mock_open(), create=True) as mok_open:
+            mok_open.side_effect = RuntimeError('mock failure')
+            with self.assertRaises(RuntimeError):
+                self.cache.add_manager(self.vault, self.manager)
+
+    def test_shell_cache_vault_basic(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.cache.add_vault(self.vault, self.manager)
+
+        with self.assertRaises(NotImplementedError):
+            self.cache.get_vault(self.vault,
+                                 None,
+                                 None,
+                                 None)
+
+    def test_shell_cache_vault_basic_with_age(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.cache.add_vault(self.vault, self.manager)
+
+        expire_age = datetime.timedelta(weeks=52)
+
+        with self.assertRaises(NotImplementedError):
+            self.cache.get_vault(self.vault,
+                                 None,
+                                 None,
+                                 None)
+
+    def test_shell_cache_vault_expired(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+        self.cache.add_vault(self.vault, self.manager)
+
+        expire_age = datetime.timedelta(microseconds=5)
+        with self.assertRaises(ExpiredCacheData):
+            self.cache.get_vault(self.vault,
+                                 None,
+                                 None,
+                                 expire_age)
+
+    def test_shell_cache_vault_no_data(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+
+        with self.assertRaises(NoCachedData):
+            self.cache.get_vault(self.vault,
+                                 None,
+                                 None,
+                                 None)
+
+    def test_shell_cache_vault_basic_with_start_end(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+
+        start_block = create_block()[0]
+        end_block = create_block()[0]
+        self.manager = Manager(start_block, end_block)
+
+        self.cache.add_vault(self.vault, self.manager)
+
+        with self.assertRaises(NotImplementedError):
+            self.cache.get_vault(self.vault,
+                                 start_block,
+                                 end_block,
+                                 None)
+
+    def test_shell_cache_add_vault_failure(self):
+        self.cache.base = self.cache_dir
+        self.assertEqual(self.cache.base,
+                         self.cache_dir)
+
+        with mock.patch('builtins.open',
+                        mock.mock_open(), create=True) as mok_open:
+            mok_open.side_effect = RuntimeError('mock failure')
+            with self.assertRaises(RuntimeError):
+                self.cache.add_vault(self.vault, self.manager)

--- a/deucevalere/tests/test_api_system_manager_serialize.py
+++ b/deucevalere/tests/test_api_system_manager_serialize.py
@@ -7,9 +7,10 @@ import unittest
 from deuceclient.tests import *
 
 from deucevalere.api.system import *
+from deucevalere.tests.client_base import TestValereClientBase
 
 
-class DeuceValereApiSystemManagerSerializationTest(unittest.TestCase):
+class DeuceValereApiSystemManagerSerializationTest(TestValereClientBase):
 
     def setUp(self):
         super().setUp()
@@ -17,62 +18,12 @@ class DeuceValereApiSystemManagerSerializationTest(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
 
-    def __check_time_manager(self, a, b):
-        self.assertEqual(a.name, b.name)
-        self.assertEqual(a.start, b.start)
-        self.assertEqual(a.end, b.end)
-
-    def __check_counter_manager(self, a, b):
-        self.assertEqual(a.name, b.name)
-        self.assertEqual(a.count, b.count)
-        self.assertEqual(a.size, b.size)
-
-    def __check_list_manager(self, a, b):
-        def __check_list(c, d):
-            if c is None:
-                self.assertIsNone(d)
-            else:
-                self.assertEqual(c, d)
-
-        self.assertEqual(a.name, b.name)
-        __check_list(a.current, b.current)
-        __check_list(a.expired, b.expired)
-        __check_list(a.deleted, b.deleted)
-        __check_list(a.orphaned, b.orphaned)
-
-    def __check_manager(self, a, b):
-        def __check_marker(c, d):
-            if c is None:
-                self.assertIsNone(d)
-            else:
-                self.assertEqual(c, d)
-
-        self.assertEqual(a.expire_age, b.expire_age)
-        __check_marker(a.start_block, b.start_block)
-        __check_marker(a.end_block, b.end_block)
-        self.__check_time_manager(a.validation_timer,
-                                  b.validation_timer)
-        self.__check_time_manager(a.cleanup_timer,
-                                  b.cleanup_timer)
-        self.__check_counter_manager(a.expired_counter,
-                                     b.expired_counter)
-        self.__check_counter_manager(a.missing_counter,
-                                     b.missing_counter)
-        self.__check_counter_manager(a.orphaned_counter,
-                                     b.orphaned_counter)
-        self.__check_list_manager(a.metadata,
-                                  b.metadata)
-        self.__check_list_manager(a.storage,
-                                  b.storage)
-        self.assertEqual(a.cross_reference,
-                         b.cross_reference)
-
     def test_manager_serialization_default(self):
         manager = Manager()
         json_data = manager.to_json()
         deserialized_manager = Manager.from_json(json_data)
-        self.__check_manager(manager,
-                             deserialized_manager)
+        self.check_manager(manager,
+                           deserialized_manager)
 
     def test_manager_serialization_with_data(self):
         manager = Manager()
@@ -91,8 +42,8 @@ class DeuceValereApiSystemManagerSerializationTest(unittest.TestCase):
                 manager.storage.orphaned = [50, 100]
         json_data = manager.to_json()
         deserialized_manager = Manager.from_json(json_data)
-        self.__check_manager(manager,
-                             deserialized_manager)
+        self.check_manager(manager,
+                           deserialized_manager)
 
     def test_time_manager_deserialization_value_error(self):
         serialization_data = {
@@ -123,7 +74,7 @@ class DeuceValereApiSystemManagerSerializationTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             ListManager.deserialize(serialization_data)
 
-    def test_list_manager_deserialization_typee_error(self):
+    def test_list_manager_deserialization_type_error(self):
         serialization_data = {
             'name': 'fake',
             'current': datetime.datetime.max,


### PR DESCRIPTION
- Refactor: Moved some functionality from the Manager Serialization Test to the client_base so that we can use it for other tests, namely testing the shell cache which deals with serialization
- Enhancement: Added functionality to cache the Manager and Vault to disk
  - This is mainly for use between command-line instantiations so the user does not have to remember everything or be concerned with input/output functionality
  - Added appropriate testing