### PR TITLE
Enhancement try to find orphaned block sizes

### DIFF
--- a/deucevalere/__init__.py
+++ b/deucevalere/__init__.py
@@ -24,14 +24,14 @@ def version():
                               __DEUCE_VALERE_VERSION__['minor'])
 
 
-@validate(deuece_client=ClientRule,
+@validate(deuce_client=ClientRule,
           vault=VaultInstanceRule,
           manager=ValereManagerRule)
-def vault_validate(deuece_client, vault, manager,
+def vault_validate(deuce_client, vault, manager,
                    head_storage_blocks=False):
     """Validate the Deuce Vault by checking all blocks exist
 
-    :param deuece_client: instance of deuceclient.client.deuce
+    :param deuce_client: instance of deuceclient.client.deuce
                           to use for interacting with the Deuce Service
     :param vault: instance of deuceclient.api.Vault for the
                   vault to be inspected and cleaned
@@ -44,7 +44,7 @@ def vault_validate(deuece_client, vault, manager,
     log = logging.getLogger(__name__)
 
     # create the valiere client
-    valere_client = ValereClient(deuce_client=deuece_client,
+    valere_client = ValereClient(deuce_client=deuce_client,
                                  vault=vault,
                                  manager=manager)
 
@@ -104,13 +104,13 @@ def vault_validate(deuece_client, vault, manager,
     return 0
 
 
-@validate(deuece_client=ClientRule,
+@validate(deuce_client=ClientRule,
           vault=VaultInstanceRule,
           manager=ValereManagerRule)
-def vault_cleanup(deuece_client, vault, manager):
+def vault_cleanup(deuce_client, vault, manager):
     """Cleanup the Deuce Vault by removing orphaned data
 
-    :param deuece_client: instance of deuceclient.client.deuce
+    :param deuce_client: instance of deuceclient.client.deuce
                           to use for interacting with the Deuce Service
     :param vault: instance of deuceclient.api.Vault for the
                   vault to be inspected and cleaned
@@ -128,7 +128,7 @@ def vault_cleanup(deuece_client, vault, manager):
     log = logging.getLogger(__name__)
 
     # create the valiere client
-    valere_client = ValereClient(deuce_client=deuece_client,
+    valere_client = ValereClient(deuce_client=deuce_client,
                                  vault=vault,
                                  manager=manager)
 
@@ -196,13 +196,13 @@ def vault_cleanup(deuece_client, vault, manager):
     return return_value
 
 
-@validate(deuece_client=ClientRule,
+@validate(deuce_client=ClientRule,
           vault=VaultInstanceRule,
           manager=ValereManagerRule)
-def vault_reload(deuece_client, vault, manager):
+def vault_reload(deuce_client, vault, manager):
     """Validate the Deuce Vault by checking all blocks exist
 
-    :param deuece_client: instance of deuceclient.client.deuce
+    :param deuce_client: instance of deuceclient.client.deuce
                           to use for interacting with the Deuce Service
     :param vault: instance of deuceclient.api.Vault for the
                   vault to be inspected and cleaned
@@ -222,7 +222,7 @@ def vault_reload(deuece_client, vault, manager):
     log.info('***********************************************************')
 
     # create the valiere client
-    valere_client = ValereClient(deuce_client=deuece_client,
+    valere_client = ValereClient(deuce_client=deuce_client,
                                  vault=vault,
                                  manager=manager)
 

--- a/deucevalere/__init__.py
+++ b/deucevalere/__init__.py
@@ -98,6 +98,9 @@ def vault_validate(deuece_client, vault, manager,
         # here to remove this anomaly and reduce the potential erros.
         valere_client.validate_storage(skip_expired=True)
 
+    # Finally calculate the amount of current data
+    valere_client.calculate_current()
+
     return 0
 
 

--- a/deucevalere/api/system.py
+++ b/deucevalere/api/system.py
@@ -252,7 +252,8 @@ class Manager(object):
         }
         self.__counters = {
             'current': CounterManager('current'),
-            'deleted': CounterManager('deleted'),
+            'deleted_expired': CounterManager('deleted_expired'),
+            'deleted_orphaned': CounterManager('deleted_orphaned'),
             'expired': CounterManager('expired'),
             'missing': CounterManager('missing'),
             'orphaned': CounterManager('orphaned')
@@ -293,7 +294,10 @@ class Manager(object):
             },
             'counts': {
                 'current': self.__counters['current'].serialize(),
-                'deleted': self.__counters['deleted'].serialize(),
+                'deleted_expired':
+                    self.__counters['deleted_expired'].serialize(),
+                'deleted_orphaned':
+                    self.__counters['deleted_orphaned'].serialize(),
                 'expired': self.__counters['expired'].serialize(),
                 'missing': self.__counters['missing'].serialize(),
                 'orphaned': self.__counters['orphaned'].serialize()
@@ -326,8 +330,10 @@ class Manager(object):
             serialized_data['counts']['current'])
         m.__counters['expired'] = CounterManager.deserialize(
             serialized_data['counts']['expired'])
-        m.__counters['deleted'] = CounterManager.deserialize(
-            serialized_data['counts']['deleted'])
+        m.__counters['deleted_expired'] = CounterManager.deserialize(
+            serialized_data['counts']['deleted_expired'])
+        m.__counters['deleted_orphaned'] = CounterManager.deserialize(
+            serialized_data['counts']['deleted_orphaned'])
         m.__counters['missing'] = CounterManager.deserialize(
             serialized_data['counts']['missing'])
         m.__counters['orphaned'] = CounterManager.deserialize(
@@ -375,11 +381,11 @@ class Manager(object):
 
     @property
     def delete_expired_counter(self):
-        return self.__counters['deleted']
+        return self.__counters['deleted_expired']
 
     @property
     def delete_orphaned_counter(self):
-        return self.__counters['deleted']
+        return self.__counters['deleted_orphaned']
 
     @property
     def expired_counter(self):

--- a/deucevalere/api/system.py
+++ b/deucevalere/api/system.py
@@ -374,7 +374,11 @@ class Manager(object):
         return self.__counters['current']
 
     @property
-    def deleted_counter(self):
+    def delete_expired_counter(self):
+        return self.__counters['deleted']
+
+    @property
+    def delete_orphaned_counter(self):
         return self.__counters['deleted']
 
     @property

--- a/deucevalere/api/system.py
+++ b/deucevalere/api/system.py
@@ -251,6 +251,7 @@ class Manager(object):
             'cleanup': TimeManager('cleanup')
         }
         self.__counters = {
+            'current': CounterManager('current'),
             'deleted': CounterManager('deleted'),
             'expired': CounterManager('expired'),
             'missing': CounterManager('missing'),
@@ -291,6 +292,7 @@ class Manager(object):
                 'cleanup': self.__times['cleanup'].serialize()
             },
             'counts': {
+                'current': self.__counters['current'].serialize(),
                 'deleted': self.__counters['deleted'].serialize(),
                 'expired': self.__counters['expired'].serialize(),
                 'missing': self.__counters['missing'].serialize(),
@@ -320,6 +322,8 @@ class Manager(object):
             serialized_data['times']['validation'])
         m.__times['cleanup'] = TimeManager.deserialize(
             serialized_data['times']['cleanup'])
+        m.__counters['current'] = CounterManager.deserialize(
+            serialized_data['counts']['current'])
         m.__counters['expired'] = CounterManager.deserialize(
             serialized_data['counts']['expired'])
         m.__counters['deleted'] = CounterManager.deserialize(
@@ -364,6 +368,10 @@ class Manager(object):
     @property
     def cleanup_timer(self):
         return self.__times['cleanup']
+
+    @property
+    def current_counter(self):
+        return self.__counters['current']
 
     @property
     def deleted_counter(self):

--- a/deucevalere/client/valere.py
+++ b/deucevalere/client/valere.py
@@ -196,7 +196,7 @@ class ValereClient(object):
                     # do not add it a second time; try to keep the list
                     # to a minimum
                     if block_id not in self.manager.metadata.expired:
-                        self.manager.expired_counter.add(1, block.block_size)
+                        self.manager.expired_counter.add(1, len(block))
                         self.manager.metadata.expired.append(block_id)
 
             else:
@@ -269,8 +269,8 @@ class ValereClient(object):
                         #      is being traversed; it'll get cleaned up later
                         self.manager.metadata.deleted.append(expired_block_id)
 
-                        block_size = self.vault.blocks[
-                            expired_block_id].block_size
+                        block_size = len(self.vault.blocks[
+                            expired_block_id])
                         self.manager.delete_expired_counter.add(1,
                                                          block_size)
                         self.log.info('Project ID {0}, Vault {1} - '
@@ -427,7 +427,23 @@ class ValereClient(object):
                                   self.vault.vault_id,
                                   storage_id))
                 self.manager.storage.orphaned.append(storage_id)
-                self.manager.orphaned_counter.add(1, 0)
+
+                block_size = len(self.vault.storageblocks[storage_id])
+
+                if block_size == 0:
+                    mid, sid = storage_id.split('_')
+
+                    if mid in self.vault.blocks:
+                        self.log.info('Project ID {0}, Vault {1} - '
+                                      'Located block {2} matching '
+                                      'orphaned block {3}. Using for '
+                                      'block size'.format(
+                                          self.vault.project_id,
+                                          self.vault.vault_id,
+                                          mid,
+                                          storage_id))
+                        block_size = len(self.vault.blocks[mid])
+                self.manager.orphaned_counter.add(1, block_size)
 
     def validate_storage_with_head(self):
         """Check storage for orphaned blocks
@@ -490,7 +506,23 @@ class ValereClient(object):
                                   self.vault.vault_id,
                                   storage_id))
                 self.manager.storage.orphaned.append(storage_id)
-                self.manager.orphaned_counter.add(1, block.block_size)
+
+                block_size = len(block)
+
+                if block_size == 0:
+                    mid, sid = storage_id.split('_')
+
+                    if mid in self.vault.blocks:
+                        self.log.info('Project ID {0}, Vault {1} - '
+                                      'Located block {2} matching '
+                                      'orphaned block {3}. Using for '
+                                      'block size'.format(
+                                          self.vault.project_id,
+                                          self.vault.vault_id,
+                                          mid,
+                                          storage_id))
+                        block_size = len(self.vault.blocks[mid])
+                self.manager.orphaned_counter.add(1, block_size)
 
     def calculate_current(self):
         """Calculate the amount of data that is still current
@@ -498,7 +530,7 @@ class ValereClient(object):
 
         if self.manager.metadata.current is not None:
             for block_id in self.manager.metadata.current:
-                block_size = self.vault.blocks[block_id].block_size
+                block_size = len(self.vault.blocks[block_id])
                 self.manager.current_counter.add(1, block_size)
 
     def cleanup_storage(self):
@@ -566,8 +598,22 @@ class ValereClient(object):
                         # By default this will be zero and this should be
                         # valid since the oprhaned_storage_block_id comes
                         # from listing the storage blocks to start with
-                        block_size = self.vault.storageblocks[
-                            orphaned_storage_block_id].block_size
+                        block_size = len(self.vault.storageblocks[
+                            orphaned_storage_block_id])
+
+                        if block_size == 0:
+                            mid, sid = orphaned_storage_block_id.split('_')
+
+                            if mid in self.vault.blocks:
+                                self.log.info('Project ID {0}, Vault {1} - '
+                                              'Located block {2} matching '
+                                              'orphaned block {3}. Using for '
+                                              'block size'.format(
+                                                  self.vault.project_id,
+                                                  self.vault.vault_id,
+                                                  mid,
+                                                  orphaned_storage_block_id))
+                                block_size = len(self.vault.blocks[mid])
 
                         self.manager.delete_orphaned_counter.add(1, block_size)
 

--- a/deucevalere/client/valere.py
+++ b/deucevalere/client/valere.py
@@ -509,10 +509,18 @@ class ValereClient(object):
 
                 block_size = len(block)
 
+                self.log.info('Storage Block ID {0} - block size {1}'
+                              .format(storage_id, block_size))
+
                 if block_size == 0:
                     mid, sid = storage_id.split('_')
 
+                    self.log.info('\tBlock ID: {0}'.format(mid))
+                    self.log.info('\tStorage UUID: {0}'.format(sid))
+
                     if mid in self.vault.blocks:
+                        self.log.info('\tBlock ID {0} in Vault'.format(mid))
+
                         self.log.info('Project ID {0}, Vault {1} - '
                                       'Located block {2} matching '
                                       'orphaned block {3}. Using for '
@@ -521,6 +529,9 @@ class ValereClient(object):
                                           self.vault.vault_id,
                                           mid,
                                           storage_id))
+                        self.log.info('\tUpdating Block Size from {0} to {1}'
+                                      .format(block_size,
+                                              len(self.vault.blocks[mid])))
                         block_size = len(self.vault.blocks[mid])
                 self.manager.orphaned_counter.add(1, block_size)
 

--- a/deucevalere/client/valere.py
+++ b/deucevalere/client/valere.py
@@ -271,7 +271,7 @@ class ValereClient(object):
 
                         block_size = self.vault.blocks[
                             expired_block_id].block_size
-                        self.manager.deleted_counter.add(1,
+                        self.manager.delete_expired_counter.add(1,
                                                          block_size)
                         self.log.info('Project ID {0}, Vault {1} - '
                                       'Successfully Deleted Expired Block: {2}'
@@ -569,7 +569,7 @@ class ValereClient(object):
                         block_size = self.vault.storageblocks[
                             orphaned_storage_block_id].block_size
 
-                        self.manager.deleted_counter.add(1, block_size)
+                        self.manager.delete_orphaned_counter.add(1, block_size)
 
                         self.log.info('Project ID {0}, Vault {1} - '
                                       'Successfully Deleted Orphaned Block: '

--- a/deucevalere/client/valere.py
+++ b/deucevalere/client/valere.py
@@ -492,6 +492,15 @@ class ValereClient(object):
                 self.manager.storage.orphaned.append(storage_id)
                 self.manager.orphaned_counter.add(1, block.block_size)
 
+    def calculate_current(self):
+        """Calculate the amount of data that is still current
+        """
+
+        if self.manager.metadata.current is not None:
+            for block_id in self.manager.metadata.current:
+                block_size = self.vault.blocks[block_id].block_size
+                self.manager.current_counter.add(1, block_size)
+
     def cleanup_storage(self):
         """Delete orphaned blocks from storage
 

--- a/deucevalere/shell.py
+++ b/deucevalere/shell.py
@@ -198,6 +198,17 @@ def print_report(manager, title=None, show_missing=True,
                                calc_kilobytes(manager.expired_counter.size),
                                manager.expired_counter.size])
 
+    if show_deleted is True:
+        display_table.add_row(['Deleted (Expired)',
+                               manager.delete_expired_counter.count,
+                               calc_gigabytes(
+                                   manager.delete_expired_counter.size),
+                               calc_megabytes(
+                                   manager.delete_expired_counter.size),
+                               calc_kilobytes(
+                                   manager.delete_expired_counter.size),
+                               manager.delete_expired_counter.size])
+
     if show_orphaned is True:
         display_table.add_row(['Orphaned',
                                manager.orphaned_counter.count,
@@ -207,12 +218,15 @@ def print_report(manager, title=None, show_missing=True,
                                manager.orphaned_counter.size])
 
     if show_deleted is True:
-        display_table.add_row(['Deleted',
-                               manager.deleted_counter.count,
-                               calc_gigabytes(manager.deleted_counter.size),
-                               calc_megabytes(manager.deleted_counter.size),
-                               calc_kilobytes(manager.deleted_counter.size),
-                               manager.deleted_counter.size])
+        display_table.add_row(['Deleted (Orphaned)',
+                               manager.delete_orphaned_counter.count,
+                               calc_gigabytes(
+                                   manager.delete_orphaned_counter.size),
+                               calc_megabytes(
+                                   manager.delete_orphaned_counter.size),
+                               calc_kilobytes(
+                                   manager.delete_orphaned_counter.size),
+                               manager.delete_orphaned_counter.size])
 
     if title:
         print(title)

--- a/deucevalere/shell.py
+++ b/deucevalere/shell.py
@@ -231,7 +231,7 @@ def print_report(manager, title=None, show_missing=True,
                                    '-'])
 
     if show_deleted is True:
-        if manager.delete_orphaned_counter.count > 0:
+        if manager.delete_orphaned_counter.size > 0:
             display_table.add_row(['Deleted (Orphaned)',
                                    manager.delete_orphaned_counter.count,
                                    calc_gigabytes(

--- a/deucevalere/shell.py
+++ b/deucevalere/shell.py
@@ -209,24 +209,45 @@ def print_report(manager, title=None, show_missing=True,
                                    manager.delete_expired_counter.size),
                                manager.delete_expired_counter.size])
 
+    # Note: Unless we add the block size to the download deletion response
+    #       then there is no way to know how big the orphaned data is
     if show_orphaned is True:
-        display_table.add_row(['Orphaned',
-                               manager.orphaned_counter.count,
-                               calc_gigabytes(manager.orphaned_counter.size),
-                               calc_megabytes(manager.orphaned_counter.size),
-                               calc_kilobytes(manager.orphaned_counter.size),
-                               manager.orphaned_counter.size])
+        if manager.orphaned_counter.size > 0:
+            display_table.add_row(['Orphaned',
+                                   manager.orphaned_counter.count,
+                                   calc_gigabytes(
+                                       manager.orphaned_counter.size),
+                                   calc_megabytes(
+                                       manager.orphaned_counter.size),
+                                   calc_kilobytes(
+                                       manager.orphaned_counter.size),
+                                   manager.orphaned_counter.size])
+        else:
+            display_table.add_row(['Orphaned',
+                                   manager.orphaned_counter.count,
+                                   '-',
+                                   '-',
+                                   '-',
+                                   '-'])
 
     if show_deleted is True:
-        display_table.add_row(['Deleted (Orphaned)',
-                               manager.delete_orphaned_counter.count,
-                               calc_gigabytes(
-                                   manager.delete_orphaned_counter.size),
-                               calc_megabytes(
-                                   manager.delete_orphaned_counter.size),
-                               calc_kilobytes(
-                                   manager.delete_orphaned_counter.size),
-                               manager.delete_orphaned_counter.size])
+        if manager.delete_orphaned_counter.count > 0:
+            display_table.add_row(['Deleted (Orphaned)',
+                                   manager.delete_orphaned_counter.count,
+                                   calc_gigabytes(
+                                       manager.delete_orphaned_counter.size),
+                                   calc_megabytes(
+                                       manager.delete_orphaned_counter.size),
+                                   calc_kilobytes(
+                                       manager.delete_orphaned_counter.size),
+                                   manager.delete_orphaned_counter.size])
+        else:
+            display_table.add_row(['Deleted (Orphaned)',
+                                   manager.delete_orphaned_counter.count,
+                                   '-',
+                                   '-',
+                                   '-',
+                                   '-'])
 
     if title:
         print(title)

--- a/deucevalere/shell.py
+++ b/deucevalere/shell.py
@@ -175,6 +175,13 @@ def print_report(manager, title=None, show_missing=True,
     def calc_gigabytes(b):
         return calc_megabytes(b) / 1024.0
 
+    display_table.add_row(['Current',
+                           manager.current_counter.count,
+                           calc_gigabytes(manager.current_counter.size),
+                           calc_megabytes(manager.current_counter.size),
+                           calc_kilobytes(manager.current_counter.size),
+                           manager.current_counter.size])
+
     if show_missing is True:
         display_table.add_row(['Missing',
                                manager.missing_counter.count,

--- a/deucevalere/tests/__init__.py
+++ b/deucevalere/tests/__init__.py
@@ -3,11 +3,19 @@ Deuce Valere - Tests
 """
 import unittest
 
+from deuceclient.tests import *
+
 from deucevalere.api.auth import baseauth
 
 
 def minmax(a, b):
     return max(min(a, b), b)
+
+
+def create_null_block():
+    block_data = bytes()
+    block_id = get_block_id(block_data)
+    return (block_id, block_data, len(block_data))
 
 
 class FakeAuthEngine(baseauth.AuthenticationBase):

--- a/deucevalere/tests/client_base.py
+++ b/deucevalere/tests/client_base.py
@@ -159,7 +159,7 @@ class TestValereClientBase(VaultTestBase):
         for block_id in self.meta_data.keys():
             sbid = '{0}_{1}'.format(block_id, uuid.uuid4())
             bd = self.meta_data[block_id].data
-            bs = self.meta_data[block_id].block_size
+            bs = len(self.meta_data[block_id])
             rc = random.randint(0, 4)
             rmod = generate_ref_modified()
 
@@ -182,7 +182,7 @@ class TestValereClientBase(VaultTestBase):
         def make_orphaned_storage_block(block_id):
             sbid = '{0}_{1}'.format(block_id, uuid.uuid4())
             bd = self.meta_data[block_id].data
-            bs = self.meta_data[block_id].block_size
+            bs = len(self.meta_data[block_id])
             rc = random.randint(0, 4)
             rmod = generate_ref_modified()
 
@@ -358,7 +358,7 @@ class TestValereClientBase(VaultTestBase):
             headers['X-Ref-Modified'] = self.meta_data[bid].ref_modified
             headers['X-Storage-ID'] = self.meta_data[bid].storage_id
             headers['X-Block-ID'] = self.meta_data[bid].block_id
-            headers['X-Block-Size'] = self.meta_data[bid].block_size
+            headers['X-Block-Size'] = len(self.meta_data[bid])
             return (204, headers, '')
 
         else:
@@ -465,7 +465,7 @@ class TestValereClientBase(VaultTestBase):
                 self.storage_data[bid].ref_count
             headers['X-Ref-Modified'] = self.storage_data[bid].ref_modified
             headers['X-Storage-ID'] = self.storage_data[bid].storage_id
-            headers['X-Block-Size'] = self.storage_data[bid].block_size
+            headers['X-Block-Size'] = len(self.storage_data[bid])
 
             headers['X-Block-Orphaned'] = \
                 self.storage_data[bid].block_orphaned

--- a/deucevalere/tests/test_api_system_manager.py
+++ b/deucevalere/tests/test_api_system_manager.py
@@ -26,6 +26,8 @@ class DeuceValereApiSystemManagerTest(unittest.TestCase):
         self.assertIsInstance(manager.expired_counter, CounterManager)
         self.assertIsInstance(manager.missing_counter, CounterManager)
         self.assertIsInstance(manager.orphaned_counter, CounterManager)
+        self.assertIsInstance(manager.delete_expired_counter, CounterManager)
+        self.assertIsInstance(manager.delete_orphaned_counter, CounterManager)
         self.assertIsInstance(manager.metadata, ListManager)
         self.assertIsInstance(manager.storage, ListManager)
         self.assertIsInstance(manager.cross_reference, dict)

--- a/deucevalere/tests/test_client_valere.py
+++ b/deucevalere/tests/test_client_valere.py
@@ -18,3 +18,10 @@ class TestValereClientBasics(TestValereClientBase):
 
     def test_valere_client_creation(self):
         client = ValereClient(self.deuce_client, self.vault, self.manager)
+
+    def test_valere_client_calculate_current(self):
+        client = ValereClient(self.deuce_client, self.vault, self.manager)
+
+        self.assertIsNone(self.manager.metadata.current)
+
+        client.calculate_current()

--- a/deucevalere/tests/test_client_valere_validate_metadata.py
+++ b/deucevalere/tests/test_client_valere_validate_metadata.py
@@ -190,7 +190,6 @@ class TestValereClientValidateMetadata(TestValereClientBase):
         key_set = sorted(
             list(self.meta_data.keys()))[0:__min_max(len(self.meta_data), 10)]
         for key in key_set:
-            print('Setting Block {0:} to have ZERO (0) Ref Count'.format(key))
             self.meta_data[key].ref_count = 0
 
         self.client.validate_metadata()


### PR DESCRIPTION
Instead of always recording orphaned blocks as having zero-length (which they most likely don't) try to guess the length by attempting to map the orphaned block back to the actual block.

This will only really fail if the there was not HEAD operation against the actual block, which is always done in validating the blocks for Valere so this should be pretty safe.